### PR TITLE
WIP: minor edits

### DIFF
--- a/code/examples/input_output.megahit/Snakefile
+++ b/code/examples/input_output.megahit/Snakefile
@@ -1,6 +1,7 @@
 # targets: -n
 
 # ANCHOR: content
+
 rule all:
     input:
         "assembly_out"

--- a/src/beginner+/input-and-output-blocks.md
+++ b/src/beginner+/input-and-output-blocks.md
@@ -152,7 +152,7 @@ reads. Consider the following Snakefile:
 ../../code/examples/input_output.megahit/Snakefile:content}}
 ```
 
-n the shell command here, we need to supply the input reads as two
+In the shell command here, we need to supply the input reads as two
 separate files, with `-1` before one and `-2` before the second. As a
 bonus the resulting shell command is very readable!
 


### PR DESCRIPTION
(in progress)

## Related notes, will punt to issues upon completion:

Generally, in your `sketch_genomes`  rule examples, you're using `--name-from-first`. Since you're already showing wildcards, could you use --name {wildcards.accession} instead, since it's a better way to name genome sigs? Or are you concerned about that complicating things?

This would be a handy way to show that you can access the wildcards in the shell directive, too.


### Using wildcards to generalize your rules

I would bold or otherwise emphasize this sentence: 
> The first and most important rule of wildcards is this: snakemake fills in wildcard values based on the filename it is asked to produce.
