### PR TITLE
MRG: add initial command-line execution & target structuring info

### DIFF
--- a/code/examples/config.basic/config.multi_samples.yml
+++ b/code/examples/config.basic/config.multi_samples.yml
@@ -1,0 +1,4 @@
+samples:
+- DEF_789
+- GHI_234
+- JKL_567

--- a/code/examples/config.basic/config.one_sample.yml
+++ b/code/examples/config.basic/config.one_sample.yml
@@ -1,0 +1,1 @@
+sample: XYZ_123

--- a/code/examples/config.basic/config.one_sample_b.yml
+++ b/code/examples/config.basic/config.one_sample_b.yml
@@ -1,0 +1,1 @@
+sample: ABC_456

--- a/code/examples/config.basic/snakefile.multi_samples
+++ b/code/examples/config.basic/snakefile.multi_samples
@@ -1,0 +1,13 @@
+configfile: "config.multi_samples.yml"
+
+SAMPLES=config['samples']
+
+rule all:
+    input:
+        expand("one_sample.{s}.out", s=SAMPLES)
+
+rule make_single_sample_wc:
+    output:
+        "one_sample.{s}.out"
+    shell:
+        "touch {output}"

--- a/code/examples/config.basic/snakefile.multi_samples.pprint
+++ b/code/examples/config.basic/snakefile.multi_samples.pprint
@@ -1,0 +1,23 @@
+import pprint
+
+configfile: "config.multi_samples.yml"
+
+# print out the config dictionary
+print('config is:')
+pprint.pprint(config)
+
+SAMPLES=config['samples']
+
+# print out the SAMPLES variable
+print('SAMPLES is:')
+pprint.pprint(SAMPLES)
+
+rule all:
+    input:
+        expand("one_sample.{s}.out", s=SAMPLES)
+
+rule make_single_sample_wc:
+    output:
+        "one_sample.{s}.out"
+    shell:
+        "touch {output}"

--- a/code/examples/config.basic/snakefile.one_sample
+++ b/code/examples/config.basic/snakefile.one_sample
@@ -1,0 +1,9 @@
+configfile: "config.one_sample.yml"
+
+SAMPLE=config['sample']
+
+rule all:
+    output:
+        expand("one_sample.{s}.out", s=SAMPLE)
+    shell:
+        "touch {output}"

--- a/code/examples/errors.simple-fail/.gitignore
+++ b/code/examples/errors.simple-fail/.gitignore
@@ -1,0 +1,1 @@
+file-does-not-exist-typo

--- a/code/examples/errors.simple-fail/snakefile.missing-input
+++ b/code/examples/errors.simple-fail/snakefile.missing-input
@@ -1,0 +1,5 @@
+# expect_fail
+
+rule example:
+    input:
+        "file-does-not-exist"

--- a/code/examples/errors.simple-fail/snakefile.missing-output
+++ b/code/examples/errors.simple-fail/snakefile.missing-output
@@ -1,0 +1,8 @@
+# expect_fail
+
+rule example:
+    output:
+       "file-does-not-exist"
+    shell: """
+       touch file-does-not-exist-typo
+    """   

--- a/code/examples/errors.simple-fail/snakefile.shell-fail
+++ b/code/examples/errors.simple-fail/snakefile.shell-fail
@@ -1,0 +1,6 @@
+# expect_fail
+
+rule hello_fail:
+    shell: """
+        ls file-does-not-exist
+    """

--- a/code/examples/errors.simple-fail/snakefile.wildcard-error
+++ b/code/examples/errors.simple-fail/snakefile.wildcard-error
@@ -1,0 +1,5 @@
+# expect_fail
+
+rule example:
+    input: "{name}.input"
+    output: "{name}.output"

--- a/code/examples/errors.simple-fail/snakefile.wildcard-error
+++ b/code/examples/errors.simple-fail/snakefile.wildcard-error
@@ -3,3 +3,4 @@
 rule example:
     input: "{name}.input"
     output: "{name}.output"
+    shell: "cp {input} {output}"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -28,6 +28,7 @@
   - [Basic syntax rules for Snakefiles](./beginner+/syntax.md)
   - [Visualizing your workflow](./beginner+/visualizing.md)
   - [String formatting "minilanguage"](./beginner+/string-formatting.md)
+  - [Using configuration files](./beginner+/config.md)
 
 - [Section 4 - Snakemake Patterns and Recipes](./section_4.md)
   - [Subsampling FASTQ files](./recipes/subsampling-files.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -23,6 +23,7 @@
   - [Using wildcards to generalize your rules](./beginner+/wildcards.md)
   - [`params:` blocks and `{params}`](./beginner+/params-blocks.md)
   - [Using `expand` to generate filenames](./beginner+/expand.md))
+  - [Running rules and choosing targets from the command line](./beginner+/targets.md)
   - [Techniques for debugging snakemake workflows](./beginner+/debugging.md)
   - [Basic syntax rules for Snakefiles](./beginner+/syntax.md)
   - [Visualizing your workflow](./beginner+/visualizing.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -38,6 +38,7 @@
 
 - [Section 5 - Advanced Features](./section_5.md)
   - [Beyond `-j` - parallelizing snakemake](./advanced/parallel.md)
+  - [Resource constraints and job management](./advanced/resources.md)
 
 - [Section 6 - A Reference Guide for Snakemake Features](./section_6.md)
   - [Wildcard constraints](reference/wildcard-constraints.md)

--- a/src/advanced/resources.md
+++ b/src/advanced/resources.md
@@ -1,0 +1,17 @@
+# Resources, constraints, and job management
+
+## Points to make / outline
+
+* impossibility of predicting exactly; a strategy
+* how to measure with benchmarks, slurm, top (??); RSS as key thing to manage
+* CPU utilization, context switching, overhead; threads, processes
+* considerations for parallelism (perhaps also see [parallel](parallel.md)).
+
+Standard resources: mem, disk, runtime, and tmpdir
+
+Your own defined resources: other things.
+
+## Examples
+
+* set up various memory constrained jobs and run with various
+  different max memories; show overlap; make figure showing total memory used.

--- a/src/beginner+/config.md
+++ b/src/beginner+/config.md
@@ -79,11 +79,32 @@ note, might want to have some info on parameters in output files.
 
 ## Providing config variables on the command line
 
-## Debugging config files
+## Debugging config files and displaying the `config` dictionary
+
+I frequently want to know what the config actually is when running
+snakemake. A convenient way to do this is to use `pprint` -
+for example, see `snakefile.multi_samples.pprint`,
+```python
+{{#include ../../code/examples/config.basic/snakefile.multi_samples.pprint}}
+```
+which produces the following output:
+```
+config is:
+{'samples': ['DEF_789', 'GHI_234', 'JKL_567']}
+SAMPLES is:
+['DEF_789', 'GHI_234', 'JKL_567']
+```
+
+CTB: explain python dict/list, or link.
+
+CTB: link to debugging
+
+CTB: talk about -n, and Python vs ...
 
 print, pprint
 keys
-defaults
+
+using .get/providing defaults
 
 ## Recap
 

--- a/src/beginner+/config.md
+++ b/src/beginner+/config.md
@@ -1,0 +1,100 @@
+# Using configuration files
+
+Configuration files are a snakemake feature that can be used to
+separate the _rules_ in the workflow from the _configuration_ of the
+workflow.  For example, suppose that we want to run the same sequence
+trimming workflow on many different samples. With the techniques we've
+seen so far, you'd need to change the Snakefile each time; with config
+files, you can keep the Snakefile the same, and just provide a different
+config file for each new sample. Config files can also be used to
+define parameters, or override default parameters, for specific programs
+being run by your workflow.
+
+## A first example - running a rule with a single sample ID
+
+Consider this Snakefile, which create an output file based on a
+sample ID. Here the sample ID is taken from a config file and provided
+via the Python dictionary named `config`:
+```python
+{{#include ../../code/examples/config.basic/snakefile.one_sample}}
+```
+
+The default configuration file is `config.one_sample.yml`, which
+sets `config['sample']` to the value `XYZ_123`, and creates
+`one_sample.XYZ_123.out`:
+```yml
+{{#include ../../code/examples/config.basic/config.one_sample.yml}}
+```
+
+However, the `configfile:` directive in the Snakefile can be overriden
+on the command line by using `--configfile`; consider the file
+`config.one_sample_b.yml`:
+```yml
+{{#include ../../code/examples/config.basic/config.one_sample_b.yml}}
+```
+If we now run `snakemake -s snakefile.one_sample --configfile
+config.one_sample_b.yml -j 1`, the value of sample will be set to
+`ABC_456`, and the file `one_sample.ABC_456.out` will be created.
+
+(CTB: assert that the appropriate output files are created.)
+
+## Specifying multiple sample IDs in a config file
+
+The previous example only handles one sample at a time, but there's
+no reason we couldn't provide multiple, using YAML lists. Consider
+this Snakefile, `snakefile.multi_samples`:
+```python
+{{#include ../../code/examples/config.basic/snakefile.multi_samples}}
+```
+
+and this config file, `config.multi_samples.yml`:
+```yml
+{{#include ../../code/examples/config.basic/config.multi_samples.yml}}
+```
+
+Here, we're creating multiple output files, using a more complicated setup.
+
+First, we use `samples` from the config file. The `config['samples']` value
+is a Python list of strings, instead of a Python string, as in the previous
+sample; that's because the config file specifies `samples` as a list in
+the `config.multi_samples.yml` file.
+
+Second, we switched to using [a wildcard rule](wildcards.md) in the
+Snakefile, because we want to
+[run one rule on many files](wildcards.md#running-one-rule-on-many-files);
+this has a lot of benefits!
+
+Last but not least, we provide a [default rule](../chapter_10.md) that
+uses [the `expand` function with a single pattern and one list of values](expand.md#using-expand-with-a-single-pattern-and-one-list-of-values) to construct
+the list of output files for the wildcard rule to make.
+
+Now we can either edit the list of samples in the config file, or we can
+provide different config files with different lists of samples!
+
+## Specifying input spreadsheets via config file
+
+## Specifying command line parameters in a config file
+
+note, might want to have some info on parameters in output files.
+
+## Providing config variables on the command line
+
+## Debugging config files
+
+print, pprint
+keys
+defaults
+
+## Recap
+
+With config files, you can:
+
+* separate configuration from your workflow
+* provide multiple different config files for the same workflow
+* change the samples by editing a YML file instead of a Snakefile
+* make it easy to validate your input configuration (DISCUSS)
+
+## Leftovers
+
+* Point to official snakemake docs
+* Guide to YAML and JSON syntax

--- a/src/beginner+/config.md
+++ b/src/beginner+/config.md
@@ -75,9 +75,58 @@ provide different config files with different lists of samples!
 
 ## Specifying command line parameters in a config file
 
-note, might want to have some info on parameters in output files.
+Config files aren't limited to sample IDs - you can put pretty much
+anything in a config file.
 
-## Providing config variables on the command line
+Consider our `sourmash sketch` command from the workflow
+we developed in [Section 1](../chapter_0.md), where we compare genomes
+at a particular k-mer size. For example, from
+[Chapter 2](../chapter_2.md), we have:
+
+```python
+rule sketch_genomes:
+    output:
+       "GCF_000017325.1.fna.gz.sig",
+       "GCF_000020225.1.fna.gz.sig",
+       "GCF_000021665.1.fna.gz.sig"
+    shell: """
+        sourmash sketch dna -p k=31 genomes/*.fna.gz --name-from-first
+    """
+```
+
+Here, `sketch dna` is run with the parameter `-p k=31`, which sets the
+k-mer size for comparison to k=31. This is a prime candidate for a
+config file!
+
+Using [a params block](params.md) and a config file, we could rewrite this
+rule as 
+```python
+rule sketch_genomes:
+    output:
+       "GCF_000017325.1.fna.gz.sig",
+       "GCF_000020225.1.fna.gz.sig",
+       "GCF_000021665.1.fna.gz.sig",
+    params:
+        ksize=config['ksize'],
+    shell: """
+        sourmash sketch dna -p k={params.ksize} genomes/*.fna.gz --name-from-first
+    """
+```
+
+This has a few nice features:
+
+* the use of 'params' makes it clear to the reader that this is a parameter!
+* the k-mer size is configurable!
+
+CTB: check that it actually works with k=21!
+
+CTB: talk about config.get and int/type validation
+
+CTB: advanced usage: conditional parameters like output=pdf for compare.
+
+note/danger, might want to have some info on parameters in output file names...
+
+note/danger, talk about tradeoff b/t information in config file, vs information in snakefile - e.g. what programs to run, vs what parameters to use
 
 ## Debugging config files and displaying the `config` dictionary
 
@@ -99,12 +148,28 @@ CTB: explain python dict/list, or link.
 
 CTB: link to debugging
 
-CTB: talk about -n, and Python vs ...
+CTB: talk about -n, and Python statements vs rules...
 
 print, pprint
 keys
 
 using .get/providing defaults
+
+## Advanced usage
+
+### Providing config variables on the command line
+
+You can also set individual config variables on the command line:
+
+```
+snakemake -j 1 -s snakefile.one_sample -C sample=ZZZ_123
+```
+
+CTB: how to do this for lists; how to do this for multiple config variables.
+
+### Providing multiple config files
+
+`--configfiles`
 
 ## Recap
 

--- a/src/beginner+/debugging.md
+++ b/src/beginner+/debugging.md
@@ -1,5 +1,7 @@
-# Techniques for debugging workflow execution
+# Techniques for debugging workflow execution (and fixing problems!)
 
+* intermediate targets
+* debug-dag
 * logs
 * print in Snakefile (use file=)
 * finding and reading error messages - silence, killed, etc.
@@ -8,3 +10,210 @@
 * using -k
 * running in single-CPU mode
 * whitespace
+* filling in wildcards
+
+## A short check list
+
+Summary: once you're done with syntax errors:
+
+* run with `-n`
+* run with `-j 1`
+* run with `-p`
+* run just the rules you're interested in (see [targets](targets.md))
+
+## Finding, fixing, and avoiding syntax errors.
+
+### Whitespace and indentation errors: finding, fixing, and avoiding them.
+
+Use a good editor, e.g. vscode or some othe text editor. Put it in snakemake
+mode or Python mode (spaces etc.)
+
+### Syntax errors, newlines, and quoting.
+
+triple quotes vs single quotes
+
+## Debugging Snakefile workflow declarations/specifications @@
+
+wildcard errors
+
+### `MissingInputException`
+
+One of the most common errors to encounter when writing a new workflow
+is a `MissingInputException`. This is snakemake's way of saying three things:
+first, it has figured out that it _needs_ a particular file; second,
+that file does not already exist; and third,
+it doesn't know how to _make_ that file (i.e. there's no rule that produces
+that file).
+
+For example, consider this very simple workflow file:
+```python
+{{#include ../../code/examples/errors.simple-fail/snakefile.missing-input}}
+```
+
+When we run it, we get:
+```
+MissingInputException in rule example in file /Users/t/dev/2023-snakemake-book-draft/code/examples/errors.simple-fail/snakefile.missing-input, line 1:
+Missing input files for rule example:
+    affected files:
+        file-does-not-exist
+```
+
+This error comes up in two common situations: either there is an input
+file that you were supposed to provide the workflow but that is
+missing (e.g. a missing FASTQ file); or the rule that is supposed to
+produce this file (as an output) doesn't properly match.
+
+### `MissingOutputException` and increasing `--latency-wait`
+
+Sometimes you will see an error message that mentions a
+`MissingOutputException` and suggests increasing the wait time with
+`--latency-wait`.  This is most frequently a symptom of a rule that
+does not properly create an expected output file.
+
+For example, consider:
+```python
+{{#include ../../code/examples/errors.simple-fail/snakefile.missing-output}}
+```
+
+Here we have a simple rule whose output block specifies that it will
+create a file named `file-does-not-exist`, but (due to a typo in the
+shell command) creates the wrong file instead. If we run this, we will
+get the following message:
+
+```
+Waiting at most 5 seconds for missing files.
+MissingOutputException in rule example in file /Users/t/dev/2023-snakemake-book-draft/code/examples/errors.simple-fail/snakefile.missing-output, line 3:
+Job 0 completed successfully, but some output files are missing. Missing files after 5 seconds. This might be due to filesystem latency. If that is the case, consider to increase the wait time with --latency-wait:
+file-does-not-exist
+```
+
+First, let's remember that the `output:` block is simply an
+_annotation_, not a directive: it's telling snakemake what this rule
+is _supposed_ to create, without actually creating it @@ (link to
+input-output here).  The part of the rule that _creates_ the file is
+typically the `shell:` block, and, here, we've made a mistake in the
+shell block, and are creating the wrong file.
+
+**There's no simple way for snakemake to know what files were actually
+created by a shell block**, so snakemake doesn't try: it simple complains
+that we _said_ running this rule would create a particular file, but
+it _didn't_ create that file when we ran it. That's what
+`MissingOutputException` generally means.
+
+To fix this, we need to look at the shell command and understand why it is
+not creating the desired file. That can get complicated, but one common
+fix is to avoid writing filenames redundantly and instead use `{output}`
+patterns in the shell block so that you don't accidentally use
+different names in the `output:` block and in the `shell:` block.
+
+So then what is this message about waiting 5 seconds for missing
+files, and/or increasing `--latency-wait`? This refers to an advanced
+situation (discussed @@later) that can occur when we are writing to a
+shared network file system from jobs running on multiple machines. If
+you're running snakemake on a single machine, this should never be a
+problem! We'll defer discussion of this until later.
+
+## Debugging running snakemake workflows 
+
+
+## Run your rules once target at a time.
+
+## Run your rules one job at a time.
+
+## Finding and interpreting error messages
+
+### Display of error messages for failed commands
+
+## Running all the rules you can with `-k/--keep-going`
+
+Snakemake has a slighly confusing presentation of error messages from
+shell commands: the messages appear _above_ the notification that the
+rule failed
+
+Consider the following Snakefile:
+```python
+{{#include ../../code/examples/errors.simple-fail/snakefile.shell-fail}}
+```
+
+When you run this in a directory that does _not_ contain the file named `file-does-not-exist`, you will see the following output:
+
+```
+[Fri Apr 14 14:59:29 2023]                 
+rule hello_fail:
+    jobid: 0
+    reason: Rules with neither input nor output files are always executed.
+    resources: tmpdir=/var/folders/6s/_f373w1d6hdfjc2kjstq97s80000gp/T
+
+ls: cannot access 'file-does-not-exist': No such file or directory
+[Fri Apr 14 14:59:29 2023]
+Error in rule hello_fail:
+    jobid: 0
+    shell:
+        
+        ls file-does-not-exist
+    
+        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)
+```
+
+There are three parts to this output:
+
+* the first part starts at `rule hello_fail:`, and declares that snakemake
+  is going to run this rule, and gives the reason why.
+  
+* the second part contains the error message from running that
+  command - here, `ls` fails because the file in question does not
+  exist, and so it prints out `ls: cannot access
+  'file-does-not-exist': No such file or directory `. **This is the error
+  output by the failed command.**
+  
+* the third part starts at "Error in rule hello_fail" and describes the
+  rule that failed: its name `hello_fail`, its jobid, and the shell command
+  that was run (`ls file-does-not-exist`), together with some information
+  about how the failure was detected (a non-zero exit code @@) and how the
+  shell command was run (in so-called "strict mode" @@).
+  
+The somewhat non-intuitive part here is that the error message that is
+specific to the failed rule - that the file in question did not exist -
+appears _above_ the notification of failure.
+
+There are some good reasons for this (@@ something to do about stdout capture)
+and various ways to change this behavior (@@ logging) but, _by default_,
+this is how snakemake reports errors in shell commands.
+
+What this means in practice is that when you are debugging a failed
+shell command, the place to look for the snakemake error is _above_
+the notification of the failure!
+  
+@@ describe bash strict mode
+
+@@ describe (briefly) logging
+
+@@ when running with -j more than 1
+
+### Out of memory errors: "Killed".
+
+CTB: is it lowercase or uppercase?
+
+Sometimes you will see a "rule failed" @@ error from snakemake, and
+the only error message that you will be able to find is "killed".
+What is this?
+
+This generally means that your shell command (or shell process) was
+terminated by an unavoidable signal from the operating system - and
+the most common such signal is an out-of-memory error.
+
+When a process uses too much memory, the default behavior of the
+operating system is to _immediately_ terminate it - there's not much
+else to be done.  Unfortunately, the default error message explaining this
+is somewhat lacking.
+
+There is no single way to _fix_ this problem, unfortunately. A few
+general strategies include:
+
+* switching to a system with more memory, or (if you are using a queueing
+  system like slurm) requesting more memory for your job.
+* if you are using a program that asks you to specify an amount of
+  memory to use (e.g. some assemblers, or any java program), you can
+  decrease the amount of memory you request on the command line.
+* you can also decrease the size of the dataset you are using, perhaps
+  by subdiving it or subsampling @@.

--- a/src/beginner+/debugging.md
+++ b/src/beginner+/debugging.md
@@ -25,6 +25,9 @@ fixing many of them.
 * running in single-CPU mode
 * whitespace
 * filling in wildcards
+* use `--until` to specify a rule to go to
+* focus on one wildcard at a time
+* thought: maybe do a thing where we really dig into a set of debugging?
 
 @@ suggested procedure after syntax: first run with -j big and -k; then everything left will be blocking errors.
 

--- a/src/beginner+/debugging.md
+++ b/src/beginner+/debugging.md
@@ -1,5 +1,37 @@
 # Techniques for debugging workflow execution (and fixing problems!)
 
+## Some initial words of wisdom
+
+Debugging complex computer situations is an art -- or, at least, it is
+not easily systematized.  There are guidelines and even rules to
+debugging, but no single procedure or approach that is guaranteed to work.
+
+This chapter focuses on *how to debug* snakemake workflows. The odds
+are that you're reading this chapter because you are trying hard to
+get something to work. Heck, you're probably only reading this
+sentence because you're desperate.
+
+Below are the most useful pieces of advice we can give you about debugging
+at this point in your snakemake journey.
+
+First, simplify the workflow as much as possible so that it is fast to
+run. For example, reduce the number of samples to 1 or 2 (@@)
+and subsample input files so that they are small. This will make it
+faster to run and decrease the time between testing your results.
+
+Second, focus on one rule at a time. Run each rule, one by one, until
+you find one that is not doing what you want it to do. Then focus on
+fixing that. This will provide you with an increasingly solid path
+through the snakemake rules.
+
+Third, print out the commands being run (using `-p`) and examine
+the wildcards in the snakemake output carefully. Make sure both the
+commands and the wildcard values are what you expect. Find the first
+rule where they aren't and fix that rule. This will ensure that
+at each stage, your wildcards are ...
+
+## The three stages of snakemake debugging
+
 There are three common stages of debugging you'll encounter when
 creating or modifying a snakemake workflow.
 

--- a/src/beginner+/debugging.md
+++ b/src/beginner+/debugging.md
@@ -1,25 +1,51 @@
 # Techniques for debugging workflow execution (and fixing problems!)
 
+There are three common stages of debugging you'll encounter when
+creating or modifying a snakemake workflow.
+
+First, you'll have syntax errors caused by mismatched indentation and
+whitespace, as well as mismatched quotes. These errors will prevent
+snakemake from reading your Snakefile.
+
+Second, you'll find problems connecting rules and filling in wildcards.
+This will prevent snakemake from executing any jobs.
+
+And third, you'll have actual execution errors that make specific rules
+or jobs fail. These errors will prevent your workflow from finishing.
+
+This chapter will cover the sources of the most common types of
+these errors, and will also provide tips and techniques for avoiding or
+fixing many of them.
+
 * intermediate targets
 * debug-dag
 * logs
 * print in Snakefile (use file=)
 * finding and reading error messages - silence, killed, etc.
-* the most common error messages - wildcards, output missing, input missing, whitespace/tabs etc
-* using -n
-* using -k
 * running in single-CPU mode
 * whitespace
 * filling in wildcards
 
-## A short check list
+## After the syntax errors: running your snakemake workflow
 
-Summary: once you're done with syntax errors:
+CTB: make this an admonish block.
 
-* run with `-n`
-* run with `-j 1`
-* run with `-p`
-* run just the rules you're interested in (see [targets](targets.md))
+Here is a short list of tactics to use when trying to debug execution
+errors in your snakemake workflow -- that is, _after_ you resolve
+any syntax errors preventing snakemake from reading the Snakefile.
+
+1. Run snakemake with `-n/--dry-run`, and inspect the output. This will
+   tell you if the snakemake workflow will run the rules and produce
+   the output you're actually interested in.
+2. Run snakemake with `-j/--cores 1`. This will run your jobs one after
+   the other, in serial mode; this will make the output from snakemake
+   jobs less confusing, because only one job will be running at a time.
+3. Run snakemake with `-p/--printshellcmds`. This will print out the
+   actual shell commands that are being run.
+4. Run just the rules you're trying to debug by specifying either the
+   rule name or a filename on the command line (see
+   [Running rules and choosing targets from the command line](targets.md)
+   for more information).
 
 ## Finding, fixing, and avoiding syntax errors.
 
@@ -31,6 +57,8 @@ mode or Python mode (spaces etc.)
 ### Syntax errors, newlines, and quoting.
 
 triple quotes vs single quotes
+
+deleting lines.
 
 ## Debugging Snakefile workflow declarations/specifications @@
 

--- a/src/beginner+/debugging.md
+++ b/src/beginner+/debugging.md
@@ -26,9 +26,8 @@ fixing many of them.
 * whitespace
 * filling in wildcards
 
-## After the syntax errors: running your snakemake workflow
 
-CTB: make this an admonish block.
+~~~admonish info title='After the syntax errors: running your snakemake workflow'
 
 Here is a short list of tactics to use when trying to debug execution
 errors in your snakemake workflow -- that is, _after_ you resolve
@@ -46,6 +45,8 @@ any syntax errors preventing snakemake from reading the Snakefile.
    rule name or a filename on the command line (see
    [Running rules and choosing targets from the command line](targets.md)
    for more information).
+
+~~~
 
 ## Finding, fixing, and avoiding syntax errors.
 
@@ -147,7 +148,7 @@ wildcards.
 
 Consider:
 ```python
-{{#include ../../code/examples/errors.simple-fail/snakefile.missing-output}}
+{{#include ../../code/examples/errors.simple-fail/snakefile.wildcard-error}}
 ```
 
 which generates:
@@ -156,7 +157,34 @@ WorkflowError:
 Target rules may not contain wildcards. Please specify concrete files or a rule without wildcards at the command line, or have a rule without wildcards at the very top of your workflow (e.g. the typical "rule all" which just collects all results you want to generate in the end).
 ```
 
-See [Using wildcards to generalize your rules](wildcards.md#all-wildcards-used-in-a-rule-must-match-to-wildcards-in-the-output-block) and [Targets](targets.md) for more information.
+This error occurs in this case because there is only one rule in the
+snakemake workflow, and when werun `snakemake` it will default to
+running that rule as its target. However, that rule uses
+[wildcards](wildcards.md) in its output block, and hence cannot be a
+target.
+
+You can also encounter this error when you specify a rule name explicitly;
+if the rule you ask snakemake to run by name contains a wildcard in its
+output block, you can't run the rule directly - you have to give it a
+filename that snakemake can use to infer the wildcard.
+
+In either case, the solution is to either ask snakemake to build a
+filename, or give snakemake a target that does not include
+wildcards. For example, if the file `XYZ.input` existed in the
+directory, here we could either specify `XYZ.output` on the command
+line, or we could write a new default rule that specified the name
+`XYZ.output` as a pseudo-target:
+```python
+rule all:
+    input:
+        "XYZ.output"
+```
+Either solution has the effect of providing the rule `example` with a value
+to substitute for the wildcard `name`.
+
+See
+[Using wildcards to generalize your rules](wildcards.md#all-wildcards-used-in-a-rule-must-match-to-wildcards-in-the-output-block)
+and [Targets](targets.md) for more information.
 
 ## Debugging running snakemake workflows 
 

--- a/src/beginner+/debugging.md
+++ b/src/beginner+/debugging.md
@@ -26,6 +26,8 @@ fixing many of them.
 * whitespace
 * filling in wildcards
 
+@@ suggested procedure after syntax: first run with -j big and -k; then everything left will be blocking errors.
+
 
 ~~~admonish info title='After the syntax errors: running your snakemake workflow'
 

--- a/src/beginner+/debugging.md
+++ b/src/beginner+/debugging.md
@@ -25,7 +25,7 @@ Summary: once you're done with syntax errors:
 
 ### Whitespace and indentation errors: finding, fixing, and avoiding them.
 
-Use a good editor, e.g. vscode or some othe text editor. Put it in snakemake
+Use a good editor, e.g. vscode or some other text editor. Put it in snakemake
 mode or Python mode (spaces etc.)
 
 ### Syntax errors, newlines, and quoting.
@@ -33,8 +33,6 @@ mode or Python mode (spaces etc.)
 triple quotes vs single quotes
 
 ## Debugging Snakefile workflow declarations/specifications @@
-
-wildcard errors
 
 ### `MissingInputException`
 
@@ -113,6 +111,25 @@ shared network file system from jobs running on multiple machines. If
 you're running snakemake on a single machine, this should never be a
 problem! We'll defer discussion of this until later.
 
+### `WorkflowError` and wildcards
+
+Another common error is a `WorfklowError: Target rules may not contain
+wildcards." This occurs when snakemake is asked to run a rule that contains
+wildcards.
+
+Consider:
+```python
+{{#include ../../code/examples/errors.simple-fail/snakefile.missing-output}}
+```
+
+which generates:
+```
+WorkflowError:
+Target rules may not contain wildcards. Please specify concrete files or a rule without wildcards at the command line, or have a rule without wildcards at the very top of your workflow (e.g. the typical "rule all" which just collects all results you want to generate in the end).
+```
+
+See [Using wildcards to generalize your rules](wildcards.md#all-wildcards-used-in-a-rule-must-match-to-wildcards-in-the-output-block) and [Targets](targets.md) for more information.
+
 ## Debugging running snakemake workflows 
 
 
@@ -126,7 +143,7 @@ problem! We'll defer discussion of this until later.
 
 ## Running all the rules you can with `-k/--keep-going`
 
-Snakemake has a slighly confusing presentation of error messages from
+Snakemake has a slightly confusing presentation of error messages from
 shell commands: the messages appear _above_ the notification that the
 rule failed
 
@@ -210,10 +227,10 @@ is somewhat lacking.
 There is no single way to _fix_ this problem, unfortunately. A few
 general strategies include:
 
-* switching to a system with more memory, or (if you are using a queueing
+* switching to a system with more memory, or (if you are using a queuing
   system like slurm) requesting more memory for your job.
 * if you are using a program that asks you to specify an amount of
   memory to use (e.g. some assemblers, or any java program), you can
   decrease the amount of memory you request on the command line.
 * you can also decrease the size of the dataset you are using, perhaps
-  by subdiving it or subsampling @@.
+  by subdividing it or sub-sampling @@.

--- a/src/beginner+/input-and-output-blocks.md
+++ b/src/beginner+/input-and-output-blocks.md
@@ -3,6 +3,8 @@
 @@ make a note somewhere that these are annotations, not directives,
 and that's why we suggest using `{output}`.
 
+@@ make a note saying that if it wants one output, it will run the rule.
+
 As we saw in [Chapter 2](../chapter_2.md), snakemake will automatically
 "chain" rules by connecting inputs to outputs. That is, snakemake
 will figure out _what to run_ in order to produce the desired output,

--- a/src/beginner+/input-and-output-blocks.md
+++ b/src/beginner+/input-and-output-blocks.md
@@ -1,5 +1,8 @@
 # `input:` and `output:` blocks
 
+@@ make a note somewhere that these are annotations, not directives,
+and that's why we suggest using `{output}`.
+
 As we saw in [Chapter 2](../chapter_2.md), snakemake will automatically
 "chain" rules by connecting inputs to outputs. That is, snakemake
 will figure out _what to run_ in order to produce the desired output,

--- a/src/beginner+/string-formatting.md
+++ b/src/beginner+/string-formatting.md
@@ -10,5 +10,6 @@ Maybe should add stuff about interacting in/with python?
 https://docs.python.org/3/library/string.html#formatspec
 
 * quoting
+* using quotes in string templates for keys (or, like, not doing that)
 * operations
 * escaping `{` and `}`

--- a/src/beginner+/string-formatting.md
+++ b/src/beginner+/string-formatting.md
@@ -3,6 +3,10 @@
 The ~5 things you need to know;
 Q: how does this intersect with `expand`?
 
+Maybe should add stuff about interacting in/with python?
+* f strings vs templates in snakemake
+* string "constants" etc
+
 https://docs.python.org/3/library/string.html#formatspec
 
 * quoting

--- a/src/beginner+/targets.md
+++ b/src/beginner+/targets.md
@@ -3,6 +3,21 @@
 The way that you specify targets in snakemake is simple, but can lead
 to a lot of complexity in its details.
 
+* key points: what you put on the command line - "targets" - is mirror image
+  of snakefile
+* snakefile organization can/should reflect
+* difference between rule names and filenames; wildcard rules and not.
+
+USe language: "pseudo-rules "
+
+snakemake docs link:
+https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#targets-and-aggregation
+
+set:
+```
+default_target: True
+```
+
 ## Default targets
 
 If you just run `snakemake -j 1`, snakemake will run the first rule it

--- a/src/beginner+/targets.md
+++ b/src/beginner+/targets.md
@@ -9,10 +9,23 @@ If you just run `snakemake -j 1`, snakemake will run the first rule it
 encounters. This can be adjusted by @@.
 
 The typical way to use this is to provide a rule 'all' at the top of
-the Snakefile that looks like this: @@. Often these rules contain only
-a list of input files, as in Chapter XYZ; for rules with no output or
-shell commands, snakemake will work to satisfy the rule preconditions
-(i.e. to generate the input files), which is what you want.
+the Snakefile that looks like this:
+```python
+rule all:
+    input:
+        ...
+```
+Typically this rule contains one or more input files, and no other
+rule blocks; for example, in [Chapter 11](../chapter_11.md), the
+default rule 
+
+This is because for rules with no output or shell commands, snakemake
+will work to satisfy the rule preconditions (i.e. to generate the
+input files), which is all you need for a default rule.
+
+So the default rule, often named `all`, should contain a single input
+block which in turns has a list of all of the "default" output output
+files that the workflow should produce.
 
 ## Concrete targets: using rule names vs using filenames
 
@@ -21,17 +34,53 @@ line, in any mixture. It does not guarantee a particular order to run
 them in, although it will generally run them in the order specified on
 the command line.
 
+For example, for the Snakefile from [Chapter 11](../chapter_11.md),
+you could run `snakemake -j 1 compare_genomes` to execute just the
+`compare_genomes` rule, or you could add `plot_comparison` to execute
+both `compare_genomes` and `plot_comparison`, or you could just run
+`plot_comparison` which will run `compare_genomes` anyway because `plot_comparison` relies on the output of `compare_genomes`.
+
 ## Executing wildcard targets using filenames
 
 Rules containing wildcards cannot be executed by rule name, because 
 snakemake does not have enough information to fill in the wildcards.
 
-However, you can run wildcard targets using filenames!
+So you could not run `snakemake -j 1 sketch_genomes` because that rule
+has a wildcard in it: in order to run the rule, snakemake needs to
+fill in the `accession` wildcard, and just giving it the rule name
+isn't sufficient.
+
+However, you can run wildcard targets using filenames! If you run
+`snakemake -j 1 GCF_000017325.1.fna.gz.sig` then snakemake will
+find the rule that produces an output file of that form
+(which in this case is the `sketch_genome` rule), and run it, filling
+in the wildcard from the specified output file name.
+
+So snakemake will happily run rules by name, as long as they don't contain
+wildcards; or it will find and run the rules necessary to produce any
+specified files, as long as it can find rules that produce those files;
+or a mixture.
 
 ## Organizing your workflow with multiple concrete targets
 
 You can provide multiple concrete target names that build specific sets of
 files. This is useful when building or debugging your workflow.
+
+Consider again the Snakefile from [Chapter 11](../chapter_11.md). There
+are rules to run `sourmash compare` and rules to produce the output plot,
+but there isn't a rule that will produce _just_ the signature files.
+
+We can add such a rule easily: somewhere below rule `all`, we would add:
+```
+rule build_sketches:
+    input:
+        expand("{acc}.fna.gz.sig", acc=ACCESSIONS)
+```
+then executing `snakemake -j 1 build_sketches` would produce four
+.sig files, and do nothing else.
+
+The difference between this and the `compare_genomes` rule is that
+`compare_genomes` also runs `sourmash compare`.
 
 @CTB: recipe with toplevel
 

--- a/src/beginner+/targets.md
+++ b/src/beginner+/targets.md
@@ -1,0 +1,44 @@
+# Running rules and choosing targets from the command line
+
+The way that you specify targets in snakemake is simple, but can lead
+to a lot of complexity in its details.
+
+## Default targets
+
+If you just run `snakemake -j 1`, snakemake will run the first rule it
+encounters. This can be adjusted by @@.
+
+The typical way to use this is to provide a rule 'all' at the top of
+the Snakefile that looks like this: @@. Often these rules contain only
+a list of input files, as in Chapter XYZ; for rules with no output or
+shell commands, snakemake will work to satisfy the rule preconditions
+(i.e. to generate the input files), which is what you want.
+
+## Concrete targets: using rule names vs using filenames
+
+snakemake will happily take rule names and/or filenames on the command
+line, in any mixture. It does not guarantee a particular order to run
+them in, although it will generally run them in the order specified on
+the command line.
+
+## Executing wildcard targets using filenames
+
+Rules containing wildcards cannot be executed by rule name, because 
+snakemake does not have enough information to fill in the wildcards.
+
+However, you can run wildcard targets using filenames!
+
+## Organizing your workflow with multiple concrete targets
+
+You can provide multiple concrete target names that build specific sets of
+files. This is useful when building or debugging your workflow.
+
+@CTB: recipe with toplevel
+
+## Advice on structuring your snakefile
+
+* provide a default rule
+* provide one or more concrete rules that are well named
+* do not expect people (including yourself) to remember your filename layout
+  or your rule names without documentation ;).
+

--- a/src/chapter_11.md
+++ b/src/chapter_11.md
@@ -1,9 +1,41 @@
 # Chapter 11 - our final Snakefile - review and discussion
 
-Here's the final Snakefile:
+Here's the final Snakefile for comparing four genomes.
+
+This snakemake workflow has the following features:
+
+* it has a single list of accessions at the top of the Snakefile, so
+  that more genomes can be added by changing only one place in the
+  file. See
+  [Using `expand` with a single pattern and one list of values](../beginner+/expand.md#using-expand-with-a-single-pattern-and-one-list-of-values)
+  for more discussion of this.
+  
+* the workflow uses a default rule `all`, a "pseudo-rule" that
+  contains only input files. This is the default rule that snakemake
+  will run if executed without any targets on the command line. See
+  [Running rules and choosing targets from the command line](./beginner+/targets.md)
+  for some discussion of targets and Snakefile organization.
+  
+* the workflow uses one wildcard rule, `sketch_genome`, to convert
+  _multiple_ genome files ending in `.fna.gz` into sourmash signature files.
+  See [Using wildcards to generalize your rules](./beginner+/wildcards.md) for
+  discussion of wildcards.
+  
+* there is also a rule `compare_genomes` that uses `expand` to
+  construct the complete list of genomes signature needed to run
+  `sourmash compare`.  Again, see
+  [using `expand` with a single pattern and one list of values](../beginner+/expand.md#using-expand-with-a-single-pattern-and-one-list-of-values)
+  for more discussion of this.
+  
+* the last rule, `plot_comparison`, takes the output of `compare_genomes`
+  and turns it into a PNG image via `sourmash plot` via the provided
+  shell command.
 
 ```python
 {{#include ../code/section2/interm6.snakefile}}
 ```
 
-@@ add discussion!
+In the following sections we will cover the core features of snakemake
+used in this Snakefile more thoroughly, and then introduce some more
+complex bioinformatics workflows as well as a number of useful
+patterns and reusable recipes.


### PR DESCRIPTION
Addresses https://github.com/ngs-docs/2023-snakemake-book-draft/issues/25 by adding information on command line targets and other command line functionality of snakemake.

Also adds:
* draft chapter on debugging and errors.
* draft chapter on configuration files
* stub chapter on resource management
